### PR TITLE
FIx issues with components startup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM eu.gcr.io/gitpod-core-dev/build/installer:main.3413 AS installer
 
-FROM rancher/k3s:v1.22.9-rc4-k3s1
+FROM rancher/k3s:v1.21.12-k3s1
 
 ADD https://github.com/FiloSottile/mkcert/releases/download/v1.4.4/mkcert-v1.4.4-linux-amd64 /bin/mkcert
 RUN chmod +x /bin/mkcert

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,14 @@
-FROM eu.gcr.io/gitpod-core-dev/build/installer:main.3237 AS installer
+FROM eu.gcr.io/gitpod-core-dev/build/installer:main.3413 AS installer
 
-FROM rancher/k3s:v1.21.12-k3s1
+FROM rancher/k3s:v1.22.9-rc4-k3s1
 
 ADD https://github.com/FiloSottile/mkcert/releases/download/v1.4.4/mkcert-v1.4.4-linux-amd64 /bin/mkcert
 RUN chmod +x /bin/mkcert
 
 ADD https://github.com/krallin/tini/releases/download/v0.19.0/tini-static /tini
 RUN chmod +x /tini
+
+ADD https://github.com/cert-manager/cert-manager/releases/download/v1.8.0/cert-manager.yaml /var/lib/rancher/k3s/server/manifests/cert-manager.yaml
 
 ADD https://github.com/mikefarah/yq/releases/download/v4.25.1/yq_linux_amd64 /bin/yq 
 RUN chmod +x /bin/yq

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ simple as possible.
 ## Installation
 
 ```bash
-sudo docker run --privileged --name gitpod --rm -it -v /tmp/workspaces:/var/gitpod/workspaces 5000-gitpodio-previewinstall-ox4ypumem4w.ws-us46.gitpod.io/gitpod-k3s:latest
+sudo docker run --privileged --name gitpod --rm -it -v /tmp/gitpod:/var/gitpod 5000-gitpodio-previewinstall-ox4ypumem4w.ws-us46.gitpod.io/gitpod-k3s:latest
 ```
 
 Once the above command starts running and the pods are ready (can be checked by running `docker exec gitpod kubectl get pods`), 
@@ -18,6 +18,9 @@ docker inspect -f '{{range.NetworkSettings.Networks}}{{.IPAddress}}{{end}}' gitp
 ```
 
 [nip.io](https://nip.io/) is just wildcard DNS for local addresses, So all off this is local, and cannot be accessed over the internet.
+
+As the `self-hosted` instance is self-signed, The root certificate to upload into your browser trust store to access the URL is available at
+`/tmp/gitpod/gitpod-ca.crt`.
 
 ## Known Issues
 

--- a/README.md
+++ b/README.md
@@ -10,8 +10,14 @@ simple as possible.
 sudo docker run --privileged --name gitpod --rm -it -v /tmp/workspaces:/var/gitpod/workspaces 5000-gitpodio-previewinstall-ox4ypumem4w.ws-us46.gitpod.io/gitpod-k3s:latest
 ```
 
-Once the above command is ran, Your gitpod instance can be accessed at `172-17-17-172.nip.io`. [nip.io](https://nip.io/) is just wildcard DNS for local addresses, So all
-of this is local, and cannot be accessed over the internet.
+Once the above command starts running and the pods are ready (can be checked by running `docker exec gitpod kubectl get pods`), 
+The URL to access your gitpod instance can be retrieved by running
+
+```
+docker inspect -f '{{range.NetworkSettings.Networks}}{{.IPAddress}}{{end}}' gitpod |  sed -r 's/[.]+/-/g' | sed 's/$/.nip.io/g'
+```
+
+[nip.io](https://nip.io/) is just wildcard DNS for local addresses, So all off this is local, and cannot be accessed over the internet.
 
 ## Known Issues
 

--- a/README.md
+++ b/README.md
@@ -1,15 +1,18 @@
-# Gitpod in a Docker container with k3s
+# Gitpod Preview Installation
 
-**This is merely a starting point**
+This repo helps users to try out and preview self-hosted Gitpod **locally** without all the things
+needed for a production instance. The aim is to provide an installation mechanism as minimal and
+simple as possible.
 
-Things that are working:
-- latest installer is integrated
-- PVCs are provisioned using `local-path`
-- All containers go out of pending (some don't work because of the `buildin-registry-certs` issue)
+## Installation
 
-Things that are missing:
-- generating self-signed certs in the entrypoint.sh
-- all the DNS setup, e.g. patching CoreDNS in the entrypoint
+```bash
+sudo docker run --privileged --name gitpod --rm -it -v /tmp/workspaces:/var/gitpod/workspaces 5000-gitpodio-previewinstall-ox4ypumem4w.ws-us46.gitpod.io/gitpod-k3s:latest
+```
 
-Things that are not working:
-- the `builtin-registry-certs` secret seems to be missing
+Once the above command is ran, Your gitpod instance can be accessed at `172-17-17-172.nip.io`. [nip.io](https://nip.io/) is just wildcard DNS for local addresses, So all
+of this is local, and cannot be accessed over the internet.
+
+## Known Issues
+
+- Prebuilds don't work as they require webhooks support over the internet.

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -87,6 +87,7 @@ yq e -i ".customCACert.kind = \"secret\"" config.yaml
 yq e -i ".observability.logLevel = \"debug\"" config.yaml
 yq e -i '.workspace.runtime.containerdSocket = "/run/k3s/containerd/containerd.sock"' config.yaml
 yq e -i '.workspace.runtime.containerdRuntimeDir = "/var/lib/rancher/k3s/agent/containerd/io.containerd.runtime.v2.task/k8s.io/"' config.yaml
+yq e -i '.experimental.webapp.server.workspaceDefaults.workspaceImage = "docker.io/gitpod/workspace-base:latest"' config.yaml
 
 echo "extracting images to download ahead..."
 /gitpod-installer render --config config.yaml | grep 'image:' | sed 's/ *//g' | sed 's/image://g' | sed 's/\"//g' | sed 's/^-//g' | sort | uniq > /gitpod-images.txt
@@ -96,7 +97,7 @@ do
    ctr images pull $image &>/dev/null &
 done
 
-ctr images pull "docker.io/gitpod/workspace-full:latest" &>/dev/null &
+ctr images pull "docker.io/gitpod/workspace-base:latest" &>/dev/null &
 
 /gitpod-installer render --config config.yaml --output-split-files /var/lib/rancher/k3s/server/manifests/gitpod
 for f in /var/lib/rancher/k3s/server/manifests/gitpod/*.yaml; do (cat "$f"; echo) >> /var/lib/rancher/k3s/server/gitpod.debug; done

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -86,6 +86,16 @@ yq e -i ".observability.logLevel = \"debug\"" config.yaml
 yq e -i '.workspace.runtime.containerdSocket = "/run/k3s/containerd/containerd.sock"' config.yaml
 yq e -i '.workspace.runtime.containerdRuntimeDir = "/var/lib/rancher/k3s/agent/containerd/io.containerd.runtime.v2.task/k8s.io/"' config.yaml
 
+echo "extracting images to download ahead..."
+/gitpod-installer render --config config.yaml | grep 'image:' | sed 's/ *//g' | sed 's/image://g' | sed 's/\"//g' | sed 's/^-//g' | sort | uniq > /gitpod-images.txt
+echo "downloading images..."
+cat /gitpod-images.txt | while read image
+do
+   ctr images pull $image &>/dev/null &
+done
+
+ctr images pull "docker.io/gitpod/workspace-full:latest" &>/dev/null &
+
 /gitpod-installer render --config config.yaml --output-split-files /var/lib/rancher/k3s/server/manifests/gitpod
 for f in /var/lib/rancher/k3s/server/manifests/gitpod/*.yaml; do (cat "$f"; echo) >> /var/lib/rancher/k3s/server/gitpod.debug; done
 rm /var/lib/rancher/k3s/server/manifests/gitpod/*NetworkPolicy*

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-set -eux -o pipefile
+set -ex -o pipefail
 
 # check for minimum requirements
 REQUIRED_MEM_KB=$((6 * 1024 * 1024))
@@ -18,9 +18,11 @@ if [ $total_cores -lt $((REQUIRED_CORES)) ]; then
 fi
 
 # Get container's IP address
-NODE_IP=$(hostname -i)
-DOMAIN_STRING=${NODE_IP//[.]/-}
-DOMAIN="${DOMAIN_STRING}.nip.io"
+if [ -z "${DOMAIN}" ]; then
+  NODE_IP=$(hostname -i)
+  DOMAIN_STRING=${NODE_IP//[.]/-}
+  DOMAIN="${DOMAIN_STRING}.nip.io"
+fi
 
 echo "Gitpod Domain: $DOMAIN"
 
@@ -37,7 +39,7 @@ fi
 
 mount --make-shared /sys/fs/cgroup
 mount --make-shared /proc
-mount --make-shared /var/gitpod
+mount --make-shared /var/gitpod/workspaces
 
 mkcert -install
 # install in local store

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,10 +2,7 @@
 
 set -eux -o pipefile
 
-if [ -z "$DOMAIN" ]; then
-    >&2 echo "Error: Environment variable DOMAIN is missing."
-    exit 1;
-fi
+DOMAIN="172-17-17-172.nip.io"
 
 # M1 and cgroupsv2 stuff
 if ! grep -iq 'cpu.*hz' /proc/cpuinfo; then
@@ -90,6 +87,9 @@ rm /var/lib/rancher/k3s/server/manifests/gitpod/*NetworkPolicy*
 for f in /var/lib/rancher/k3s/server/manifests/gitpod/*PersistentVolumeClaim*.yaml; do yq e -i '.spec.storageClassName="local-path"' "$f"; done
 yq eval-all -i '. as $item ireduce ({}; . *+ $item)' /var/lib/rancher/k3s/server/manifests/gitpod/*_StatefulSet_messagebus.yaml /app/manifests/messagebus.yaml 
 for f in /var/lib/rancher/k3s/server/manifests/gitpod/*StatefulSet*.yaml; do yq e -i '.spec.volumeClaimTemplates[0].spec.storageClassName="local-path"' "$f"; done
+
+# assign specific external IP for the `proxy` service
+yq eval-all -i '.spec.externalIPs = ["172.17.17.172"]' /var/lib/rancher/k3s/server/manifests/gitpod/*_Service_proxy.yaml
 
 # removing init container from ws-daemon (systemd and Ubuntu)
 yq eval-all -i 'del(.spec.template.spec.initContainers[0])' /var/lib/rancher/k3s/server/manifests/gitpod/*_DaemonSet_ws-daemon.yaml

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,6 +2,21 @@
 
 set -eux -o pipefile
 
+# check for minimum requirements
+REQUIRED_MEM_KB=$((6 * 1024 * 1024))
+total_mem_kb=$(cat /proc/meminfo | awk '/MemTotal:/ {print $2}')
+if [ $total_mem_kb -lt $((REQUIRED_MEM_KB)) ]; then
+    echo "Preview installation of Gitpod requires a system with at least 6GB of memory"
+    exit 1
+fi
+
+REQUIRED_CORES=4
+total_cores=$(nproc)
+if [ $total_cores -lt $((REQUIRED_CORES)) ]; then
+    echo "Preview installation of Gitpod requires a system with at least 4 CPU Cores"
+    exit 1
+fi
+
 # Get container's IP address
 NODE_IP=$(hostname -i)
 DOMAIN_STRING=${NODE_IP//[.]/-}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -9,14 +9,6 @@ DOMAIN="${DOMAIN_STRING}.nip.io"
 
 echo "Gitpod Domain: $DOMAIN"
 
-# M1 and cgroupsv2 stuff
-if ! grep -iq 'cpu.*hz' /proc/cpuinfo; then
-  cpuinfo_file=/etc/cpuinfo_with_fake_speed
-  cp /proc/cpuinfo $cpuinfo_file
-  echo "CPU MHz: 2345.678" >> $cpuinfo_file
-  mount --bind $cpuinfo_file /proc/cpuinfo
-fi
-
 if [ -f /sys/fs/cgroup/cgroup.controllers ]; then
   echo "[$(date -Iseconds)] [CgroupV2 Fix] Evacuating Root Cgroup ..."
 	# move the processes from the root group to the /init group,

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -30,11 +30,13 @@ fi
 
 mount --make-shared /sys/fs/cgroup
 mount --make-shared /proc
-mount --make-shared /var/gitpod/workspaces
+mount --make-shared /var/gitpod
 
 mkcert -install
 # install in local store
 cat $HOME/.local/share/mkcert/rootCA.pem >> /etc/ssl/certs/ca-certificates.crt
+# also send root cert into a volume
+cat $HOME/.local/share/mkcert/rootCA.pem > /var/gitpod/gitpod-ca.crt
 
 cat << EOF > /var/lib/rancher/k3s/server/manifests/ca-pair.yaml
 apiVersion: v1

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -7,118 +7,80 @@ if [ -z "$DOMAIN" ]; then
     exit 1;
 fi
 
-
-
-FN_CACERT="/certs/ca.pem"
-FN_SSLCERT="/certs/ssl.crt"
-FN_SSLKEY="/certs/ssl.key"
-FN_CAKEY="/certs/ca.key"
-FN_CSREXT="/certs/cert.ext"
-
-if [ ! -f "$FN_CACERT" ] && [ ! -f "$FN_SSLCERT" ] && [ ! -f "$FN_SSLKEY" ]; then
-    [ ! -d /certs ] && mkdir -p /certs
-
-    /bin/mkcert \
-      -cert-file "$FN_SSLCERT" \
-      -key-file "$FN_SSLKEY" \
-      "*.ws.${DOMAIN}" "*.${DOMAIN}" "${DOMAIN}" "ws-manager" "wsdaemon"
-    CAROOT="/certs" /bin/mkcert -install
-    mv /certs/rootCA.pem "$FN_CACERT"
+# M1 and cgroupsv2 stuff
+if ! grep -iq 'cpu.*hz' /proc/cpuinfo; then
+  cpuinfo_file=/etc/cpuinfo_with_fake_speed
+  cp /proc/cpuinfo $cpuinfo_file
+  echo "CPU MHz: 2345.678" >> $cpuinfo_file
+  mount --bind $cpuinfo_file /proc/cpuinfo
 fi
+
+if [ -f /sys/fs/cgroup/cgroup.controllers ]; then
+  echo "[$(date -Iseconds)] [CgroupV2 Fix] Evacuating Root Cgroup ..."
+	# move the processes from the root group to the /init group,
+  # otherwise writing subtree_control fails with EBUSY.
+  mkdir -p /sys/fs/cgroup/init
+  busybox xargs -rn1 < /sys/fs/cgroup/cgroup.procs > /sys/fs/cgroup/init/cgroup.procs || :
+  # enable controllers
+  sed -e 's/ / +/g' -e 's/^/+/' <"/sys/fs/cgroup/cgroup.controllers" >"/sys/fs/cgroup/cgroup.subtree_control"
+  echo "[$(date -Iseconds)] [CgroupV2 Fix] Done"
+fi
+
+mount --make-shared /sys/fs/cgroup
+mount --make-shared /proc
+mount --make-shared /var/gitpod/workspaces
+
+mkcert -install
+# install in local store
+cat $HOME/.local/share/mkcert/rootCA.pem >> /etc/ssl/certs/ca-certificates.crt
+
+cat << EOF > /var/lib/rancher/k3s/server/manifests/ca-pair.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: ca-key-pair
+data:
+  ca.crt: $(cat $HOME/.local/share/mkcert/rootCA.pem | base64 -w0)
+  tls.crt: $(cat $HOME/.local/share/mkcert/rootCA.pem | base64 -w0)
+  tls.key: $(cat $HOME/.local/share/mkcert/rootCA-key.pem | base64 -w0)
+EOF
+
+cat << EOF > /var/lib/rancher/k3s/server/manifests/issuer.yaml
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: ca-issuer
+spec:
+  ca:
+    secretName: ca-key-pair
+EOF
+
+echo "creating Gitpod SSL secret..."
+cat << EOF > /var/lib/rancher/k3s/server/manifests/https-cert.yaml
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: https-cert
+spec:
+  secretName: https-certificates
+  issuerRef:
+    name: ca-issuer
+    kind: Issuer
+  dnsNames:
+    - "$DOMAIN"
+    - "*.$DOMAIN"
+    - "*.ws.$DOMAIN"
+EOF
 
 mkdir -p /var/lib/rancher/k3s/server/manifests/gitpod
 
-CACERT=$(base64 -w0 < "$FN_CACERT")
-SSLCERT=$(base64 -w0 < "$FN_SSLCERT")
-SSLKEY=$(base64 -w0 < "$FN_SSLKEY")
-
-cat << EOF > /var/lib/rancher/k3s/server/manifests/gitpod/customCA-cert.yaml
----
-apiVersion: v1
-kind: Secret
-metadata:
-  name: ca-cert
-  labels:
-    app: gitpod
-data:
-  ca.crt: $CACERT
-EOF
-
-cat << EOF > /var/lib/rancher/k3s/server/manifests/gitpod/https-cert.yaml
----
-apiVersion: v1
-kind: Secret
-metadata:
-  name: https-cert
-  labels:
-    app: gitpod
-data:
-  tls.crt: $SSLCERT
-  tls.key: $SSLKEY
-EOF
-
-cat << EOF > /var/lib/rancher/k3s/server/manifests/gitpod/registry-cert.yaml
----
-apiVersion: v1
-kind: Secret
-metadata:
-  name: builtin-registry-certs
-  labels:
-    app: gitpod
-data:
-  ca.crt: $CACERT
-  tls.crt: $SSLCERT
-  tls.key: $SSLKEY
-EOF
-
-cat << EOF > /var/lib/rancher/k3s/server/manifests/gitpod/manager-cert.yaml
----
-apiVersion: v1
-kind: Secret
-metadata:
-  name: ws-manager-client-tls
-  labels:
-    app: gitpod
-data:
-  ca.crt: $CACERT
-  tls.crt: $SSLCERT
-  tls.key: $SSLKEY
-EOF
-
-cat << EOF > /var/lib/rancher/k3s/server/manifests/gitpod/ws-manager-cert.yaml
----
-apiVersion: v1
-kind: Secret
-metadata:
-  name: ws-manager-tls
-  labels:
-    app: gitpod
-data:
-  ca.crt: $CACERT
-  tls.crt: $SSLCERT
-  tls.key: $SSLKEY
-EOF
-
-cat << EOF > /var/lib/rancher/k3s/server/manifests/gitpod/ws-daemon-cert.yaml
----
-apiVersion: v1
-kind: Secret
-metadata:
-  name: ws-daemon-tls
-  labels:
-    app: gitpod
-data:
-  ca.crt: $CACERT
-  tls.crt: $SSLCERT
-  tls.key: $SSLKEY
-EOF
-
 /gitpod-installer init > config.yaml
 yq e -i '.domain = "'"$DOMAIN"'"' config.yaml
-yq e -i ".certificate.name = \"https-cert\"" config.yaml
+yq e -i ".certificate.name = \"https-certificates\"" config.yaml
 yq e -i ".certificate.kind = \"secret\"" config.yaml
-yq e -i ".customCACert.name = \"ca-cert\"" config.yaml
+yq e -i ".customCACert.name = \"ca-key-pair\"" config.yaml
 yq e -i ".customCACert.kind = \"secret\"" config.yaml
+yq e -i ".observability.logLevel = \"debug\"" config.yaml
 yq e -i '.workspace.runtime.containerdSocket = "/run/k3s/containerd/containerd.sock"' config.yaml
 yq e -i '.workspace.runtime.containerdRuntimeDir = "/var/lib/rancher/k3s/agent/containerd/io.containerd.runtime.v2.task/k8s.io/"' config.yaml
 
@@ -128,77 +90,13 @@ rm /var/lib/rancher/k3s/server/manifests/gitpod/*NetworkPolicy*
 for f in /var/lib/rancher/k3s/server/manifests/gitpod/*PersistentVolumeClaim*.yaml; do yq e -i '.spec.storageClassName="local-path"' "$f"; done
 yq eval-all -i '. as $item ireduce ({}; . *+ $item)' /var/lib/rancher/k3s/server/manifests/gitpod/*_StatefulSet_messagebus.yaml /app/manifests/messagebus.yaml 
 for f in /var/lib/rancher/k3s/server/manifests/gitpod/*StatefulSet*.yaml; do yq e -i '.spec.volumeClaimTemplates[0].spec.storageClassName="local-path"' "$f"; done
- 
+
+# removing init container from ws-daemon (systemd and Ubuntu)
+yq eval-all -i 'del(.spec.template.spec.initContainers[0])' /var/lib/rancher/k3s/server/manifests/gitpod/*_DaemonSet_ws-daemon.yaml
+
 for f in /var/lib/rancher/k3s/server/manifests/gitpod/*.yaml; do (cat "$f"; echo) >> /var/lib/rancher/k3s/server/manifests/gitpod.yaml; done
 rm -rf /var/lib/rancher/k3s/server/manifests/gitpod
 
-# gitpod-helm-installer.yaml needs access to kubernetes by the public host IP.
-kubeconfig_replacip() {
-    while [ ! -f /etc/rancher/k3s/k3s.yaml ]; do sleep 1; done
-    HOSTIP=$(hostname -i)
-    sed "s+127.0.0.1+$HOSTIP+g" /etc/rancher/k3s/k3s.yaml > /etc/rancher/k3s/k3s_.yaml
-}
-kubeconfig_replacip &
-
-installation_completed_hook() {
-    echo "Waiting for pods to be ready ..."
-    kubectl wait --for=condition=ready pod -l app=gitpod --timeout 30s
-
-    echo "Removing network policies ..."
-    kubectl delete networkpolicies.networking.k8s.io --all
-
-    echo "Removing installer manifest ..."
-    rm -f /var/lib/rancher/k3s/server/manifests/gitpod.yaml
-}
-installation_completed_hook &
-
-# add HTTPS certs secret
-if [ -f /certs/chain.pem ] && [ -f /certs/dhparams.pem ] && [ -f /certs/fullchain.pem ] && [ -f /certs/privkey.pem ]; then
-  CHAIN=$(base64 --wrap=0 < /certs/chain.pem)
-  DHPARAMS=$(base64 --wrap=0 < /certs/dhparams.pem)
-  FULLCHAIN=$(base64 --wrap=0 < /certs/fullchain.pem)
-  PRIVKEY=$(base64 --wrap=0 < /certs/privkey.pem)
-  cat << EOF > /var/lib/rancher/k3s/server/manifests/proxy-config-certificates.yaml
-apiVersion: v1
-kind: Secret
-metadata:
-  name: proxy-config-certificates
-  labels:
-    app: gitpod
-data:
-  chain.pem: $CHAIN
-  dhparams.pem: $DHPARAMS
-  fullchain.pem: $FULLCHAIN
-  privkey.pem: $PRIVKEY
-EOF
-fi
-
-
-# patch DNS config
-# if [ -n "$DOMAIN" ] && [ -n "$DNSSERVER" ]; then
-#     patchdns() {
-#         echo "Waiting for CoreDNS to patch config ..."
-#         while [ -z "$(kubectl get pods -n kube-system | grep coredns | grep Running)" ]; do sleep 10; done
-
-#         DOMAIN=$1
-#         DNSSERVER=$2
-
-#         if [ -z "$(kubectl get configmap -n kube-system coredns -o json | grep $DOMAIN)" ]; then
-#             echo "Patching CoreDNS config ..."
-
-#             kubectl get configmap -n kube-system coredns -o json | \
-#                 sed -e "s+.:53+$DOMAIN {\\\\n  forward . $DNSSERVER\\\\n}\\\\n.:53+g" | \
-#                 kubectl apply -f -
-#             echo "CoreDNS config patched."
-#         else
-#             echo "CoreDNS has been patched already."
-#         fi
-#     }
-#     patchdns "$DOMAIN" "$DNSSERVER" &
-# fi
-
-
-# start k3s
 /bin/k3s server --disable traefik \
   --node-label gitpod.io/workload_meta=true \
   --node-label gitpod.io/workload_ide=true \


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

At this point, All the **pods startup correctly** and the
DNS stuff is left to be figured out. 

To not waste too much time on a specific cert issue 
(that prevented `ws-daemon` from starting up), 
I've moved to use  `cert-manager` but it can be replaced 
in a separate PR. This should be a simple change
and gives us time to focus on the important DNS stuff.


Signed-off-by: Tarun Pothulapati <tarun@gitpod.io>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
